### PR TITLE
Fix memory stomp due to incorrect malloc size.

### DIFF
--- a/src/PRDevice.cpp
+++ b/src/PRDevice.cpp
@@ -1173,7 +1173,7 @@ PRResult PRDevice::WriteDataRaw(uint32_t moduleSelect, uint32_t startingAddr, in
 	PRResult res;
     uint32_t * buffer;
 
-    buffer = (uint32_t *)malloc((numWriteWords * 4) + 1);
+    buffer = (uint32_t *)malloc((numWriteWords * 4) + 4);
     buffer[0] = CreateBurstCommand(moduleSelect, startingAddr, numWriteWords);
     memcpy(buffer+1, writeBuffer, numWriteWords * 4);
     res = WriteData(buffer, numWriteWords + 1);


### PR DESCRIPTION
In a release build this code would often function without noticable issues, but could cause random issues elsewhere.
