### PR TITLE
updates to libpinproc (lamps, compilation issues)

### DIFF
--- a/src/PRCommon.h
+++ b/src/PRCommon.h
@@ -37,6 +37,4 @@
 void PRLog(PRLogLevel level, const char *format, ...);
 void PRSetLastErrorText(const char *format, ...);
 
-#define NULL 0
-
 #endif /* PINPROC_PRCOMMON_H */

--- a/src/PRDevice.cpp
+++ b/src/PRDevice.cpp
@@ -574,11 +574,17 @@ PRResult PRDevice::DriverAuxSendCommands(PRDriverAuxCommand * commands, uint8_t 
     uint32_t convertedCommand;
     uint32_t addr;
 
-    addr = (P_ROC_DRIVER_AUX_MEM_DECODE << P_ROC_DRIVER_CTRL_DECODE_SHIFT) |
-           startingAddr;
+    if (chip_id == P_ROC_CHIP_ID)
+    {
+        addr = (P_ROC_DRIVER_AUX_MEM_DECODE << P_ROC_DRIVER_CTRL_DECODE_SHIFT) | startingAddr;
+        commandBuffer[0] = CreateBurstCommand(P_ROC_BUS_DRIVER_CTRL_SELECT, addr, numCommands);
+    }
+    else // chip == P3_ROC_CHIP_ID)
+    {
+        addr = 0;
+        commandBuffer[0] = CreateBurstCommand(P3_ROC_BUS_AUX_CTRL_SELECT, addr, numCommands);
+    }
 
-    commandBuffer[0] = CreateBurstCommand(P_ROC_BUS_DRIVER_CTRL_SELECT, 
-                                          addr, numCommands);
     for (k=0; k<numCommands; k++) {
         convertedCommand = CreateDriverAuxCommand(commands[k]);
         commandBuffer[k+1] = convertedCommand;

--- a/src/PRDevice.cpp
+++ b/src/PRDevice.cpp
@@ -357,7 +357,7 @@ PRResult PRDevice::DriverLoadMachineTypeDefaults(PRMachineType machineType, uint
     const bool mappedSternDriverGroupPolarity[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     const int lastWPCCoilDriverGroup = 9;
     const int lastSternCoilDriverGroup = 7;
-    const int mappedWPCDriverGroupSlowTime[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 100, 100, 100, 100, 100, 100, 100, 0, 0, 0, 0, 0, 0, 0, 0};
+    const int mappedWPCDriverGroupSlowTime[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 400, 400, 400, 400, 400, 400, 400, 400, 0, 0, 0, 0, 0, 0, 0, 0};
     const int mappedSternDriverGroupSlowTime[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400, 400};
     const int mappedWPCDriverGroupActivateIndex[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0, 0, 0, 0, 0};
     const int mappedSternDriverGroupActivateIndex[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};

--- a/src/PRHardware.cpp
+++ b/src/PRHardware.cpp
@@ -28,7 +28,7 @@
  *  libpinproc
  */
 
-
+#include <stdlib.h>
 #include "PRHardware.h"
 #include "PRCommon.h"
 

--- a/utils/pinprocfw/pinprocfw.cpp
+++ b/utils/pinprocfw/pinprocfw.cpp
@@ -2188,12 +2188,12 @@ int checkPROCFile() {
 
     // Check for valid board ID and rev
     if (board_id != file_board_id) {
-        fprintf(stderr, "\nERROR: board type mismatch.", board_id);
+        fprintf(stderr, "\nERROR: board type mismatch.");
         if (board_id == P_ROC_CHIP_ID && file_board_id == P3_ROC_CHIP_ID)
-            fprintf(stderr, "\nCannot program a P3-ROC image onto a P-ROC\n\n", file_board_id, board_id);
+            fprintf(stderr, "\nCannot program a P3-ROC image onto a P-ROC\n\n");
         else if (board_id == P3_ROC_CHIP_ID && file_board_id == P_ROC_CHIP_ID)
-            fprintf(stderr, "\nCannot program a P-ROC image onto a P3-ROC\n\n", file_board_id, board_id);
-        else fprintf(stderr, "\nBoard and image are incompatible\n\n", file_board_id, board_id);
+            fprintf(stderr, "\nCannot program a P-ROC image onto a P3-ROC\n\n");
+        else fprintf(stderr, "\nImage (0x%08X) and board (0x%08X) are incompatible\n\n", file_board_id, board_id);
         return 0;
     }
     else fprintf(stderr, "\nBoard ID verified");


### PR DESCRIPTION
I incorporated changes from koen (and unintentionally included a bunch of whitespace changes) that address a dim lamps issue with WPC and using DriverAuxSendCommands() to a P3-ROC.  I've also made changes to correct compilation issues under Linux.