### PR TITLE
correct #include path to ftdi.h from libftdi1

### DIFF
--- a/src/PRHardware.cpp
+++ b/src/PRHardware.cpp
@@ -491,7 +491,7 @@ int PRHardwareWrite(uint8_t *buffer, int bytes)
 
 #else // WIN32
 
-#include <ftdi.h>
+#include <libftdi1/ftdi.h>
 
 static bool ftdiInitialized;
 static ftdi_context ftdic;


### PR DESCRIPTION
This is a required change when I try to compile on Linux.  On my system, the ftdi.h header from my libftdi1-1.2 installation is in `/usr/local/include/libftdi1/`.  I seem to recall Gabe's installation script modifies the include paths in order to find the header, but I feel that this modification is the correct/proper solution.  Note that it does not affect Windows compilation.